### PR TITLE
chore: update mockserver to 7.5.0

### DIFF
--- a/config-server-core/pom.xml
+++ b/config-server-core/pom.xml
@@ -16,7 +16,7 @@
         <!-- arquillian -->
         <system-stubs.version>2.1.8</system-stubs.version>
         <postgresql.jdbc.version>42.7.12</postgresql.jdbc.version>
-        <org.mock-server.version>5.15.0</org.mock-server.version>
+        <org.mock-server.version>7.5.0</org.mock-server.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Why

MockServer 5.15.0 shipped in January 2023 and was the last release before the project went dormant. Upstream resumed in
May 2026 with 6.0.0 and has since reached 7.5.0. Beyond keeping the test stack current, 7.5.0 closes a response-template
remote-code-execution path (GHSA-7pwj-xvc2-hfpc) that is open in every earlier release.

Tracking issue: Netcracker/qubership-core-infra#303

## What

`org.mock-server.version` in `config-server-core`: 5.15.0 -> 7.5.0. This covers both `mockserver-netty` and
`mockserver-client-java`, which are declared with that property.

No test code changes are needed. The tests use only `ClientAndServer` and the `HttpRequest`/`HttpResponse` model, and
neither changed across 6.x and 7.x. MockServer 7.x requires Netty 4.2, which matches what the Spring Boot BOM already
manages, and no response templates are used, so the sandbox defaults tightened in 7.5.0 have no effect here.

## How to verify

`Maven verify`. The MockServer-driven tests are `MicroserviceWebClientFactoryTest` and `PostgresqlConfigurationTest` in
`config-server-core`.
