### PR TITLE
chore: migrate flyway to 12.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
         <jacoco.plugin.version>0.8.15</jacoco.plugin.version>
         <spring-cloud-config-server.version>5.0.4</spring-cloud-config-server.version>
+        <flyway.version>12.10.0</flyway.version>
         <sonar.coverage.jacoco.xmlReportPaths>
             ${project.basedir}/../config-server-report-aggregate/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>


### PR DESCRIPTION
## Why

`qubership-core-java-libs` has already moved to Flyway 12.10.0. This repository still resolved
Flyway 11.14.1, the default that `spring-boot-starter-parent` 4.0.7 brings in, which left the two
codebases on different major versions of the migration engine.

Refs Netcracker/qubership-core-infra#304

## What

Pin `<flyway.version>12.10.0</flyway.version>` in the aggregator pom. Because
`spring-boot-starter-parent` is a real parent here and manages `flyway-core` and
`flyway-database-postgresql` through `${flyway.version}`, overriding the property is enough — no
`dependencyManagement` block is needed. The imported `core-spring-external-bom` 1.0.7 does not
manage Flyway, so it does not compete for the version.

`qubership-core-java-libs` pins Flyway in the `dependencyManagement` of `core-internal-bom`
instead, because there the Spring Boot BOM is imported and a property override would not reach it.

No code changes were required. The V12 breaking changes — the removed MongoDB driver, SQLFluff 4,
`cleanOnValidationError`, and the `commandExtension` signature — do not apply to this repository.
`MigrationConfiguration` and the nine `V1_*` migrations use only `Flyway.configure()`,
`FluentConfiguration`, `BaseJavaMigration`, `Context`, `repair()`, and `migrate()`, all unchanged
in V12.

## How to verify

Confirm the resolved version:

```bash
mvn -B -ntp dependency:tree -Dincludes=org.flywaydb
```

All modules report `org.flywaydb:flyway-core:12.10.0` and
`org.flywaydb:flyway-database-postgresql:12.10.0`.

Run the tests:

```bash
mvn -B -ntp test
```

41 tests pass across `config-server-core` and `config-server-app`, including the ones that exercise
Flyway against H2: `MigrationConfigurationTest`, `PostgresqlConfigurationTest`,
`EnvironmentRepositoryTest`, `MigrationControllerTest`, and `LoadConfigPropertiesTest`.

Locally, `ConsulServiceTest` was excluded because it needs Docker for Testcontainers, which was
unavailable in that environment. It is unrelated to Flyway and runs in CI.
